### PR TITLE
Stop assuming Koji tag names don't change

### DIFF
--- a/estuary/models/koji.py
+++ b/estuary/models/koji.py
@@ -62,4 +62,4 @@ class KojiTag(EstuaryStructuredNode):
 
     builds = RelationshipTo('KojiBuild', 'CONTAINS')
     id_ = UniqueIdProperty(db_property='id')
-    name = StringProperty(required=True)
+    name = StringProperty()

--- a/scrapers/koji.py
+++ b/scrapers/koji.py
@@ -186,7 +186,7 @@ class KojiScraper(BaseScraper):
             current_tag_ids = set()
             for _tag in tags:
                 current_tag_ids.add(_tag['tag_id'])
-                tag = KojiTag.get_or_create(dict(
+                tag = KojiTag.create_or_update(dict(
                     id_=_tag['tag_id'],
                     name=_tag['tag_name']
                 ))[0]


### PR DESCRIPTION
I ran into some issue rerunning the Koji scraper and this seems to be the culprit.