### PR TITLE
Convert existing KojiBuilds to ContainerKojiBuilds if necessary

### DIFF
--- a/estuary/models/base.py
+++ b/estuary/models/base.py
@@ -189,3 +189,11 @@ class EstuaryStructuredNode(StructuredNode):
             results_list.append(temp)
 
         return results_list
+
+    def add_label(self, new_label):
+        """
+        Add a Neo4j label to an existing node.
+
+        :param str new_label: the new label to add to the node
+        """
+        self.cypher('MATCH (a) WHERE id(a)={0} SET a :{1}'.format('{self}', new_label))

--- a/scrapers/koji.py
+++ b/scrapers/koji.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import xml.etree.ElementTree as ET
 import json
 
+import neomodel
+
 from scrapers.base import BaseScraper
 from estuary.models.koji import ContainerKojiBuild, KojiBuild, KojiTask, KojiTag
 from estuary.models.user import User
@@ -171,7 +173,18 @@ class KojiScraper(BaseScraper):
                 container_build = True
 
             if container_build:
-                build = ContainerKojiBuild.create_or_update(build_params)[0]
+                try:
+                    build = ContainerKojiBuild.create_or_update(build_params)[0]
+                except neomodel.exceptions.ConstraintValidationFailed:
+                    # This must have errantly been created as a KojiBuild instead of a
+                    # ContainerKojiBuild, so let's fix that.
+                    build = KojiBuild.nodes.get_or_none(id_=build_params['id_'])
+                    if not build:
+                        # If there was a constraint validation failure and the build isn't just the
+                        # wrong label, then we can't recover.
+                        raise
+                    build.add_label(ContainerKojiBuild.__label__)
+                    build = ContainerKojiBuild.create_or_update(build_params)[0]
             else:
                 build = KojiBuild.create_or_update(build_params)[0]
 

--- a/scrapers/koji.py
+++ b/scrapers/koji.py
@@ -165,7 +165,8 @@ class KojiScraper(BaseScraper):
             container_build = False
             # Checking a heuristic for determining if a build is a container build since, currently
             # there is no definitive way to do it.
-            if extra_json and extra_json.get('container_koji_build_id'):
+            if extra_json and (extra_json.get('container_koji_build_id') or
+                               extra_json.get('container_koji_task_id')):
                 container_build = True
             # Checking another heuristic for determining if a build is a container build since
             # currently there is no definitive way to do it.


### PR DESCRIPTION
Convert existing KojiBuilds to ContainerKojiBuilds if necessary and add another heuristic to determine if a build is a container.