### PR TITLE
Stop pinning the version of python-neo4j-driver

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -9,8 +9,6 @@ RUN dnf -y install \
     bash \
     python3-flask \
     python3-gunicorn \
-    # Until 1.6.0 is supported, we need to hardcode this entry
-    python3-neo4j-driver-1.5.3 \
     python3-neomodel \
     python3-six \
     && dnf clean all

--- a/docker/Dockerfile-scrapers
+++ b/docker/Dockerfile-scrapers
@@ -17,8 +17,6 @@ RUN dnf -y install \
     --setopt=tsflags=nodocs \
     python3-beautifulsoup4 \
     python3-flask \
-    # Until 1.6.0 is supported, we need to hardcode this entry
-    python3-neo4j-driver-1.5.3 \
     python3-neomodel \
     python3-psycopg2 \
     python3-PyYAML \

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -10,9 +10,6 @@ RUN dnf -y install \
   python3-flake8 \
   python2-flask \
   python3-flask \
-  # Until 1.6.0 is supported, we need to hardcode these two entries
-  python2-neo4j-driver-1.5.3 \
-  python3-neo4j-driver-1.5.3 \
   python2-neomodel \
   python3-neomodel \
   python2-pytest \


### PR DESCRIPTION
Stop pinning the version of python-neo4j-driver since the latest version now works