### PR TITLE
Reduce the chunk size to 5000 in the dist-git scraper

### DIFF
--- a/scrapers/distgit.py
+++ b/scrapers/distgit.py
@@ -62,7 +62,7 @@ class DistGitScraper(BaseScraper):
         :rtype: generator
         """
         list_iterator = iter(results)
-        chunk_size = 10000
+        chunk_size = 5000
         count = 0
         while True:
             chunk = list(islice(list_iterator, chunk_size))


### PR DESCRIPTION
I was still getting OOM errors even after converting to multi-processing. Let's try reducing the chunk size.