### PR TITLE
Overwrite results with the formatted results in the dist-git scraper

### DIFF
--- a/scrapers/distgit.py
+++ b/scrapers/distgit.py
@@ -49,7 +49,9 @@ class DistGitScraper(BaseScraper):
             self._update_neo4j, neomodel_config.DATABASE_URL, len(results))
         # Create a multi-processing pool to process chunks of results
         pool = Pool(2)
-        pool.map(_update_neo4j_partial, self._get_result_chunks(results))
+        # Overwrite results with the formatted results so we don't have to store both in RAM
+        results = list(self._get_result_chunks(results))
+        pool.map(_update_neo4j_partial, results)
         log.info('Initial load of dist-git commits complete!')
 
     @staticmethod


### PR DESCRIPTION
The dist-git scraper stores the results from the Teiid query in the `results` variable. Then it used to run `pool.map` on a method that formatted the results and returned a generator object. The issue is that it seems `pool.map` exhausts the generator right away, causing some data to be duplicated unnecessarily (not sure how much in the results variable and the formatted results point to the same objects in RAM). This may be negligible, but I think it's worth doing to save what we can.

@sarah256 could you please review this?