### PR TITLE
Refactor the dist-git scraper to not reuse processes while multi-processing

### DIFF
--- a/scrapers/distgit.py
+++ b/scrapers/distgit.py
@@ -231,7 +231,7 @@ class DistGitScraper(BaseScraper):
         namespaces = ('rpms', 'containers', 'modules', 'tests')
         cgit_url = getenv('ESTUARY_CGIT_URL', 'http://pkgs.devel.redhat.com/cgit/')
         for namespace in namespaces:
-            url = '{0}{1}/{2}/commit/?id={3}'.format(cgit_url, namespace, repo, commit)
+            url = '{0}{1}/{2}/commit/?id={3}&dt=2'.format(cgit_url, namespace, repo, commit)
             log.debug('Trying the URL "{0}"'.format(url))
             try:
                 cgit_result = session.get(url, timeout=15)


### PR DESCRIPTION
It turns out that using a multiprocess.Pool will reuse the processes rather than
destroy it and create a new one. This makes it so that the memory leak in one of
the libraries is persisting. This commit refactors this so that processes are
terminated after each chunk and created for every chunk processed.

It turns out, the memory consumption is coming from large diffs in cgit. The last commit also addresses that by using a query parameter to stop showing the diff.