### PR TITLE
Use `setup.py develop --no-deps`

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -15,7 +15,9 @@ RUN dnf -y install \
 # This will allow a non-root user to install a custom root CA at run-time
 RUN chmod 777 /etc/pki/tls/certs/ca-bundle.crt
 COPY . .
-# Install using pip so we can use the --no-deps options to ensure nothing comes from PyPi
-RUN pip3 install . --no-deps
+# Install using develop so we can use the --no-deps options to ensure nothing comes from PyPi.
+# Normally we'd use something like `pip3 install . --no-deps` but certain neomodel scripts must
+# import estuary dynamically, and for whatever reason, that fails when this is installed using pip.
+RUN python3 setup.py develop --no-deps --prefix /usr
 USER 1001
 CMD ["/usr/bin/bash", "-c", "docker/install-ca.sh && exec gunicorn-3 --bind 0.0.0.0:8080 --access-logfile=- --enable-stdio-inheritance estuary.wsgi:app"]


### PR DESCRIPTION
Use `setup.py develop --no-deps` instead of `pip3 install . --no-deps` to support dynamic imports used in the `neomodel_install_labels` script that runs after every deployment.

Unfortunately, `setup.py install` can't be used because `--no-deps` is not an option, so `setup.py develop` is used instead. There isn't really any harm in doing this, but it's not ideal.

Alternatively, I could revert to using `setup.py install` but PyPi deps would be pulled in if they were missed during the RPM installation.