### PR TITLE
Fix a key error

### DIFF
--- a/estuary/utils/general.py
+++ b/estuary/utils/general.py
@@ -462,5 +462,5 @@ def get_siblings_description(story_node_display_name, story_node_story_flow, bac
         result = '{0} {1} {2}'.format(rel_label, relationship, story_node_display_name)
         return result[0].upper() + result[1:]
     else:
-        raise RuntimeError('A node with the label {0} does not have a {1} relationship'.format(
-            story_node_story_flow['display_label'], rel_direction))
+        raise RuntimeError('{0} does not have a {1} relationship'.format(
+            story_node_display_name, rel_direction))


### PR DESCRIPTION
Fix a key error that would happen if the siblings description was requested for an invalid relationship. I know the error is not as descriptive as it was meant to be but I felt that we should not alter the function parameters to accommodate this error message that should never happen (it's a safe-guard if we have a logic error).