### PR TITLE
Remove the get_resources API endpoint

### DIFF
--- a/estuary/api/v1.py
+++ b/estuary/api/v1.py
@@ -7,7 +7,6 @@ from werkzeug.exceptions import NotFound
 from neomodel import db
 
 from estuary import version
-from estuary.models import story_flow_list
 from estuary.models.base import EstuaryStructuredNode
 
 from estuary.utils.general import (
@@ -55,17 +54,6 @@ def get_resource(resource, uid):
         return jsonify(item.serialized_all)
     else:
         return jsonify(item.serialized)
-
-
-@api_v1.route('/story')
-def get_available_resources():
-    """
-    List the available resources and their unique ID property.
-
-    :return: a Flask JSON response
-    :rtype: flask.Response
-    """
-    return jsonify({label.lower(): story_flow(label)['uid_name'] for label in story_flow_list})
 
 
 @api_v1.route('/story/<resource>/<uid>')

--- a/tests/api/test_general.py
+++ b/tests/api/test_general.py
@@ -126,19 +126,3 @@ def test_get_on_model_wo_uid(client, resource):
                    'freshmakerevent, kojibuild, kojitag, kojitask, and user.'
                    .format(resource))
     assert json.loads(rv.data.decode('utf-8')) == {'message': invalid_msg, 'status': 400}
-
-
-def test_get_resources(client):
-    """Test the /api/v1/story route."""
-    rv = client.get('/api/v1/story')
-    assert rv.status_code == 200
-    expected = {
-        'advisory': 'id',
-        'bugzillabug': 'id',
-        'containeradvisory': 'id',
-        'containerkojibuild': 'id',
-        'distgitcommit': 'hash',
-        'freshmakerevent': 'id',
-        'kojibuild': 'id',
-    }
-    assert json.loads(rv.data.decode('utf-8')) == expected


### PR DESCRIPTION
Since this is no longer used by the front-end, it'd be best to maintain less code and just remove this.

Relates to https://github.com/release-engineering/estuary/pull/62