### PR TITLE
Remove some uniqueness and required constraints on the Freshmaker label

### DIFF
--- a/estuary/models/freshmaker.py
+++ b/estuary/models/freshmaker.py
@@ -21,7 +21,6 @@ class FreshmakerEvent(EstuaryStructuredNode):
     triggered_by_advisory = RelationshipTo(
         '.errata.Advisory', 'TRIGGERED_BY', cardinality=ZeroOrOne)
     triggered_container_builds = RelationshipTo('.koji.ContainerKojiBuild', 'TRIGGERED')
-    url = StringProperty()
 
     @property
     def display_name(self):

--- a/estuary/models/freshmaker.py
+++ b/estuary/models/freshmaker.py
@@ -12,16 +12,16 @@ from estuary.models.base import EstuaryStructuredNode
 class FreshmakerEvent(EstuaryStructuredNode):
     """Definition of a Freshmaker event in Neo4j."""
 
-    event_type_id = IntegerProperty(requried=True)
+    event_type_id = IntegerProperty()
     id_ = UniqueIdProperty(db_property='id')
-    message_id = StringProperty(unique=True, required=True)
+    message_id = StringProperty()
     state = IntegerProperty()
     state_name = StringProperty()
     state_reason = StringProperty()
     triggered_by_advisory = RelationshipTo(
         '.errata.Advisory', 'TRIGGERED_BY', cardinality=ZeroOrOne)
     triggered_container_builds = RelationshipTo('.koji.ContainerKojiBuild', 'TRIGGERED')
-    url = StringProperty(unique=True, required=True)
+    url = StringProperty()
 
     @property
     def display_name(self):

--- a/tests/api/test_all_stories.py
+++ b/tests/api/test_all_stories.py
@@ -194,8 +194,7 @@ from estuary.models.freshmaker import FreshmakerEvent
                     'resource_type': 'FreshmakerEvent',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 {
                     'completion_time': '2018-04-02T19:39:06+00:00',
@@ -588,8 +587,7 @@ from estuary.models.freshmaker import FreshmakerEvent
                     'resource_type': 'FreshmakerEvent',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 {
                     'completion_time': '2018-04-02T19:39:06+00:00',
@@ -736,8 +734,7 @@ from estuary.models.freshmaker import FreshmakerEvent
                     'resource_type': 'FreshmakerEvent',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 {
                     'completion_time': '2018-04-02T19:39:06+00:00',
@@ -854,8 +851,7 @@ def test_all_stories(client, resource, uid, expected):
         'message_id': 'ID:messaging-devops-broker01.test',
         'state': 2,
         'state_name': 'COMPLETE',
-        'state_reason': 'All container images have been rebuilt.',
-        'url': '/api/1/events/1180'
+        'state_reason': 'All container images have been rebuilt.'
     })[0]
     cb = ContainerKojiBuild.get_or_create({
         'completion_time': datetime(2017, 4, 2, 19, 39, 6),

--- a/tests/api/test_general.py
+++ b/tests/api/test_general.py
@@ -64,7 +64,6 @@ def test_about(client):
         'state_name': 'SKIPPED',
         'message_id': 'Some ID',
         'state': 4,
-        'url': '/api/1/events/12345',
         'event_type_id': 8
     }),
     (ContainerKojiBuild, 'containerkojibuild', '710', {

--- a/tests/api/test_get_resource.py
+++ b/tests/api/test_get_resource.py
@@ -358,8 +358,7 @@ from estuary.models.freshmaker import FreshmakerEvent
             'release': '4.el7_4_as',
             'start_time': '2017-04-02T19:39:06+00:00',
             'state': 1,
-            'version': '1.7.4'}],
-        'url': '/api/1/events/1180'
+            'version': '1.7.4'}]
     }),
     ('containerkojibuild', '710', {
         'advisories': [
@@ -516,8 +515,7 @@ def test_get_resources(client, resource, uid, expected):
         'message_id': 'ID:messaging-devops-broker01.test',
         'state': 2,
         'state_name': 'COMPLETE',
-        'state_reason': 'All container images have been rebuilt',
-        'url': '/api/1/events/1180'
+        'state_reason': 'All container images have been rebuilt'
     })[0]
     cb = ContainerKojiBuild.get_or_create({
         'completion_time': datetime(2017, 4, 2, 19, 39, 6),

--- a/tests/api/test_relationships.py
+++ b/tests/api/test_relationships.py
@@ -43,8 +43,7 @@ from estuary.models.koji import ContainerKojiBuild
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 'version': '1.7.6'
             },
@@ -78,8 +77,7 @@ from estuary.models.koji import ContainerKojiBuild
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 'version': '1.7.5'
             },
@@ -113,8 +111,7 @@ from estuary.models.koji import ContainerKojiBuild
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 'version': '1.7.4'
             }
@@ -132,8 +129,7 @@ def test_one_to_many_node_relationships(client, resource, uid, relationship, exp
         'message_id': 'ID:messaging-devops-broker01.test',
         'state': 2,
         'state_name': 'COMPLETE',
-        'state_reason': 'All container images have been rebuilt.',
-        'url': '/api/1/events/1180'
+        'state_reason': 'All container images have been rebuilt.'
     })[0]
     cb = ContainerKojiBuild.get_or_create({
         'completion_time': datetime(2017, 4, 2, 19, 39, 6),
@@ -186,8 +182,7 @@ def test_one_to_many_node_relationships_failed(client):
         'message_id': 'ID:messaging-devops-broker01.test',
         'state': 2,
         'state_name': 'COMPLETE',
-        'state_reason': 'All container images have been rebuilt.',
-        'url': '/api/1/events/1180'
+        'state_reason': 'All container images have been rebuilt.'
     })[0]
     cb = ContainerKojiBuild.get_or_create({
         'completion_time': datetime(2017, 4, 2, 19, 39, 6),

--- a/tests/api/test_siblings.py
+++ b/tests/api/test_siblings.py
@@ -165,8 +165,7 @@ from estuary.models.freshmaker import FreshmakerEvent
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 }],
                 'update_date': '2017-08-01T07:16:00+00:00'
             }
@@ -217,8 +216,7 @@ from estuary.models.freshmaker import FreshmakerEvent
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 'version': '1.7.5'
             },
@@ -262,8 +260,7 @@ from estuary.models.freshmaker import FreshmakerEvent
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 'version': '1.7.4'
             }
@@ -396,8 +393,7 @@ def test_node_siblings(client, resource, uid, backward_rel, expected):
         'message_id': 'ID:messaging-devops-broker01.test',
         'state': 2,
         'state_name': 'COMPLETE',
-        'state_reason': 'All container images have been rebuilt.',
-        'url': '/api/1/events/1180'
+        'state_reason': 'All container images have been rebuilt.'
     })[0]
     cb = ContainerKojiBuild.get_or_create({
         'completion_time': datetime(2017, 4, 2, 19, 39, 6),

--- a/tests/api/test_story.py
+++ b/tests/api/test_story.py
@@ -105,8 +105,7 @@ from estuary.models.user import User
                 'display_name': 'Freshmaker event 1180',
                 'state': 2,
                 'state_name': 'COMPLETE',
-                'state_reason': 'All container images have been rebuilt.',
-                'url': '/api/1/events/1180'
+                'state_reason': 'All container images have been rebuilt.'
             },
             {
                 'completion_time': '2017-04-02T19:39:06+00:00',
@@ -285,8 +284,7 @@ from estuary.models.user import User
                 'display_name': 'Freshmaker event 1180',
                 'state': 2,
                 'state_name': 'COMPLETE',
-                'state_reason': 'All container images have been rebuilt.',
-                'url': '/api/1/events/1180'
+                'state_reason': 'All container images have been rebuilt.'
             },
             {
                 'completion_time': '2017-04-02T19:39:06+00:00',
@@ -433,8 +431,7 @@ from estuary.models.user import User
                 'display_name': 'Freshmaker event 1180',
                 'state': 2,
                 'state_name': 'COMPLETE',
-                'state_reason': 'All container images have been rebuilt.',
-                'url': '/api/1/events/1180'
+                'state_reason': 'All container images have been rebuilt.'
             },
             {
                 'completion_time': '2017-04-02T19:39:06+00:00',
@@ -563,8 +560,7 @@ from estuary.models.user import User
                         'message_id': 'ID:messaging-devops-broker01.test',
                         'state': 2,
                         'state_name': 'COMPLETE',
-                        'state_reason': 'All container images have been rebuilt.',
-                        'url': '/api/1/events/1180'
+                        'state_reason': 'All container images have been rebuilt.'
                     }
                 ],
                 'update_date': '2017-08-01T07:16:00+00:00'
@@ -577,8 +573,7 @@ from estuary.models.user import User
                 'display_name': 'Freshmaker event 1180',
                 'state': 2,
                 'state_name': 'COMPLETE',
-                'state_reason': 'All container images have been rebuilt.',
-                'url': '/api/1/events/1180'
+                'state_reason': 'All container images have been rebuilt.'
             },
             {
                 'completion_time': '2017-04-02T19:39:06+00:00',
@@ -725,8 +720,7 @@ from estuary.models.user import User
                         'state': 1,
                         'version': '1.7.4'
                     }
-                ],
-                'url': '/api/1/events/1180'
+                ]
             },
             {
                 'completion_time': '2017-04-02T19:39:06+00:00',
@@ -839,8 +833,7 @@ from estuary.models.user import User
                 'resource_type': 'FreshmakerEvent',
                 'state': 2,
                 'state_name': 'COMPLETE',
-                'state_reason': 'All container images have been rebuilt.',
-                'url': '/api/1/events/1180'
+                'state_reason': 'All container images have been rebuilt.'
             },
             {
                 'advisories': [
@@ -890,8 +883,7 @@ from estuary.models.user import User
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 },
                 'version': '1.7.4'
             },
@@ -993,8 +985,7 @@ from estuary.models.user import User
                 'resource_type': 'FreshmakerEvent',
                 'state': 2,
                 'state_name': 'COMPLETE',
-                'state_reason': 'All container images have been rebuilt.',
-                'url': '/api/1/events/1180'
+                'state_reason': 'All container images have been rebuilt.'
             },
             {
                 'completion_time': '2017-04-02T19:39:06+00:00',
@@ -1142,8 +1133,7 @@ def test_get_stories(client, resource, uids, expected):
         'message_id': 'ID:messaging-devops-broker01.test',
         'state': 2,
         'state_name': 'COMPLETE',
-        'state_reason': 'All container images have been rebuilt.',
-        'url': '/api/1/events/1180'
+        'state_reason': 'All container images have been rebuilt.'
     })[0]
     cb = ContainerKojiBuild.get_or_create({
         'completion_time': datetime(2017, 4, 2, 19, 39, 6),
@@ -1345,8 +1335,7 @@ def test_get_story_partial_story(client):
         'message_id': 'ID:messaging-devops-broker01.test',
         'state': 2,
         'state_name': 'COMPLETE',
-        'state_reason': 'All container images have been rebuilt.',
-        'url': '/api/1/events/1180'
+        'state_reason': 'All container images have been rebuilt.'
     })[0]
     cb = ContainerKojiBuild.get_or_create({
         'completion_time': datetime(2017, 4, 2, 19, 39, 6),
@@ -1403,8 +1392,7 @@ def test_get_story_partial_story(client):
                     'message_id': 'ID:messaging-devops-broker01.test',
                     'state': 2,
                     'state_name': 'COMPLETE',
-                    'state_reason': 'All container images have been rebuilt.',
-                    'url': '/api/1/events/1180'
+                    'state_reason': 'All container images have been rebuilt.'
                 }],
                 'update_date': '2017-08-01T07:16:00+00:00'
             },
@@ -1416,8 +1404,7 @@ def test_get_story_partial_story(client):
                 'display_name': 'Freshmaker event 1180',
                 'state': 2,
                 'state_name': 'COMPLETE',
-                'state_reason': 'All container images have been rebuilt.',
-                'url': '/api/1/events/1180'
+                'state_reason': 'All container images have been rebuilt.'
             },
             {
                 'completion_time': '2017-04-02T19:39:06+00:00',


### PR DESCRIPTION
Neomodel uses requires attributes as a way to determine if the node exists but we should restrict that to just the FreshmakerEvent ID in the event the data is not filled in entirely from a scraper or estuary-updater handler.

This also removes the useless url parameter