### PR TITLE
Add another heuristic to check for container builds

### DIFF
--- a/scrapers/base.py
+++ b/scrapers/base.py
@@ -62,14 +62,13 @@ class BaseScraper(object):
         except (ValueError, TypeError):
             extra_json = {}
 
-        # Checking a heuristic for determining if a build is a container build since, currently
+        # Checking heuristics for determining if a build is a container build, since currently
         # there is no definitive way to do it.
         if extra_json and (extra_json.get('container_koji_build_id') or
                            extra_json.get('container_koji_task_id')):
             return True
-        # Checking another heuristic for determining if a build is a container build since
-        # currently there is no definitive way to do it.
-        elif (package_name.endswith('-container') or package_name.endswith('-docker')):
+        elif extra_json.get('image') and\
+                (package_name.endswith('-container') or package_name.endswith('-docker')):
             return True
         else:
             return False


### PR DESCRIPTION
So I checked all container builds whose `name` ends with "-container"(21214 builds). Then I checked builds which did not have the `image` attribute in their `extra` among those and found only 6 such builds which were actually rpm builds(pki-core-container each one) example: https://brew.engineering.redhat.com/brew/buildinfo?buildID=741245. 

Then I found out builds not having the `extra` attribute itself and found 769 such builds. I did random checks on few of those builds and turns out they were all built by osbs. Hence, concluding that they are in-fact container builds (example: https://brew.engineering.redhat.com/brew/buildinfo?buildID=676727).

So I think this change should fix the bug of identifying the container builds correctly.

@mprahl Please let me know what you think 