### PR TITLE
Use unambiguous names when selecting Brew tables

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = D100,D104
+ignore = D100,D104,W503
 max-line-length = 100
 exclude = .git

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -21,7 +21,6 @@ RUN dnf -y install \
   python3-pytest \
   python2-pytest-cov \
   python3-pytest-cov \
-  python3-tox \
   && dnf clean all
 RUN pip install flake8-docstrings
 

--- a/estuary/models/base.py
+++ b/estuary/models/base.py
@@ -17,7 +17,7 @@ class EstuaryStructuredNode(StructuredNode):
     @property
     def display_name(self):
         """Get intuitive (human readable) display name for the node."""
-        raise NotImplemented('The display_name method is not defined')
+        raise NotImplementedError('The display_name method is not defined')
 
     @property
     def serialized(self):

--- a/estuary/models/errata.py
+++ b/estuary/models/errata.py
@@ -59,7 +59,7 @@ class Advisory(EstuaryStructuredNode):
         elif re.match(r'^RH[A-Z]{2}-\d{4}:\d+$', identifier):
             # The identifier is most of the advisory name, so return the latest iteration of this
             # advisory
-            return cls.nodes.filter(advisory_name__regex='^{0}-\d+$'.format(identifier))\
+            return cls.nodes.filter(advisory_name__regex=r'^{0}-\d+$'.format(identifier))\
                 .order_by('advisory_name').first_or_none()
         else:
             raise ValidationError('"{0}" is not a valid identifier'.format(identifier))

--- a/scrapers/base.py
+++ b/scrapers/base.py
@@ -64,8 +64,8 @@ class BaseScraper(object):
 
         # Checking heuristics for determining if a build is a container build, since currently
         # there is no definitive way to do it.
-        if extra_json and (extra_json.get('container_koji_build_id') or
-                           extra_json.get('container_koji_task_id')):
+        if extra_json and (extra_json.get('container_koji_build_id')
+                           or extra_json.get('container_koji_task_id')):
             return True
         elif extra_json.get('image') and\
                 (package_name.endswith('-container') or package_name.endswith('-docker')):

--- a/scrapers/errata.py
+++ b/scrapers/errata.py
@@ -106,8 +106,8 @@ class ErrataScraper(BaseScraper):
                             associated_build['id_']))
                         continue
 
-                    if (adv.__label__ != ContainerAdvisory.__label__ and
-                            build.__label__ == ContainerKojiBuild.__label__):
+                    if adv.__label__ != ContainerAdvisory.__label__ \
+                            and build.__label__ == ContainerKojiBuild.__label__:
                         adv.add_label(ContainerAdvisory.__label__)
 
                     adv.attached_builds.connect(build)

--- a/scrapers/koji.py
+++ b/scrapers/koji.py
@@ -54,25 +54,26 @@ class KojiScraper(BaseScraper):
         log.info('Getting all Koji builds since {0} until {1}'.format(start_date, end_date))
         sql_query = """
             SELECT
-                events.time as creation_time,
-                build.completion_time,
-                build.epoch,
-                build.extra,
-                build.id,
+                brew.events.time as creation_time,
+                brew.build.completion_time,
+                brew.build.epoch,
+                brew.build.extra,
+                brew.build.id,
                 brew.users.name as owner_name,
                 brew.users.krb_principal as owner_username,
-                package.name as package_name,
-                build.release,
-                build.start_time,
-                build.state,
-                build.task_id,
-                build.version
-            FROM build
-            LEFT JOIN events ON build.create_event = events.id
-            LEFT JOIN package ON build.pkg_id = package.id
-            LEFT JOIN brew.users ON build.owner = brew.users.id
-            WHERE events.time IS NOT NULL AND events.time >= '{0}' AND events.time <= '{1}'
-            ORDER BY build.start_time DESC;
+                brew.package.name as package_name,
+                brew.build.release,
+                brew.build.start_time,
+                brew.build.state,
+                brew.build.task_id,
+                brew.build.version
+            FROM brew.build
+            LEFT JOIN brew.events ON brew.build.create_event = brew.events.id
+            LEFT JOIN brew.package ON brew.build.pkg_id = brew.package.id
+            LEFT JOIN brew.users ON brew.build.owner = brew.users.id
+            WHERE brew.events.time IS NOT NULL AND brew.events.time >= '{0}'
+                AND brew.events.time <= '{1}'
+            ORDER BY brew.build.start_time DESC;
             """.format(start_date, end_date)
 
         return self.teiid.query(sql=sql_query)


### PR DESCRIPTION
The `package` table became ambiguous and caused the scraper to fail. This resolves it.