### PR TITLE
Remove the cardinality on KojiTag.module_builds

### DIFF
--- a/estuary/models/koji.py
+++ b/estuary/models/koji.py
@@ -87,7 +87,7 @@ class KojiTag(EstuaryStructuredNode):
 
     builds = RelationshipTo('KojiBuild', 'CONTAINS')
     id_ = UniqueIdProperty(db_property='id')
-    module_builds = RelationshipTo('ModuleKojiBuild', 'CONTAINS', cardinality=ZeroOrOne)
+    module_builds = RelationshipTo('ModuleKojiBuild', 'CONTAINS')
     name = StringProperty()
 
     @property


### PR DESCRIPTION
Since a single module build now produces a normal build and a "-devel" build, the cardinality no longer applies.

See FACTORY-3453 for context.