### PR TITLE
Allow monitoring users to access API endpoints that require auth

### DIFF
--- a/estuary/config.py
+++ b/estuary/config.py
@@ -20,6 +20,9 @@ class Config(object):
     NEO4J_URI = 'bolt://neo4j:neo4j@localhost:7687'
     CORS_URL = '*'
     STORY_MANAGER_SEQUENCE = ['ModuleStoryManager', 'ContainerStoryManager']
+    # These are service accounts that don't have "employeeType" set as "Employee" but still need
+    # access
+    MONITORING_USERS = []
     ENABLE_AUTH = False
     OIDC_INTROSPECT_URL = None
     OIDC_CLIENT_ID = None
@@ -52,3 +55,4 @@ class TestAuthConfig(TestConfig):
     OIDC_CLIENT_ID = 'estuary'
     OIDC_CLIENT_SECRET = 'some_secret'
     ENABLE_AUTH = True
+    MONITORING_USERS = ['estuary-monitoring-svc-accnt']

--- a/estuary/utils/general.py
+++ b/estuary/utils/general.py
@@ -159,8 +159,14 @@ def login_required(f):
                 raise Unauthorized(validity)
 
             token_info = current_app.oidc._get_token_info(token)
-            if (token_info.get('employeeType') != 'Employee'
-                    and token_info.get('employeeType') != 'International Local Hire'):
+            # Users that are allowed to access Estuary and won't have the "employeeType" set
+            # to "Employee"
+            monitoring_users = current_app.config['MONITORING_USERS']
+            username = token_info.get('username')
+            employee_type = token_info.get('employeeType')
+            allowed_employee_types = ('Employee', 'International Local Hire')
+            if not (monitoring_users and username and username in monitoring_users) and \
+                    employee_type not in allowed_employee_types:
                 raise Unauthorized('You must be an employee to access this service')
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
The IAM team isn't sure they can make a service account an employee. This a work-around for New Relic monitoring.