### PR TITLE
Increase the request timeout to Freshmaker's API in the Freshmaker scraper

### DIFF
--- a/scrapers/freshmaker.py
+++ b/scrapers/freshmaker.py
@@ -43,7 +43,7 @@ class FreshmakerScraper(BaseScraper):
         fm_url = self.freshmaker_url
         while True:
             log.debug('Querying {0}'.format(fm_url))
-            rv_json = session.get(fm_url, timeout=15).json()
+            rv_json = session.get(fm_url, timeout=60).json()
             for fm_event in rv_json['items']:
                 try:
                     int(fm_event['search_key'])


### PR DESCRIPTION
Some API calls take longer than 15 seconds, so it's best to just increase the timeout.