### PR TITLE
Allow the monitoring user to access Estuary

### DIFF
--- a/estuary/app.py
+++ b/estuary/app.py
@@ -53,6 +53,8 @@ def load_config(app):
         app.config['OIDC_CLIENT_SECRET'] = os.environ['OIDC_CLIENT_SECRET']
     if os.environ.get('CORS_ORIGINS'):
         app.config['CORS_ORIGINS'] = os.environ['CORS_ORIGINS'].split(',')
+    if os.environ.get('EMPLOYEE_TYPES'):
+        app.config['EMPLOYEE_TYPES'] = os.environ['EMPLOYEE_TYPES'].split(',')
 
 
 def insert_headers(response):

--- a/estuary/config.py
+++ b/estuary/config.py
@@ -25,6 +25,7 @@ class Config(object):
     OIDC_INTROSPECT_URL = None
     OIDC_CLIENT_ID = None
     OIDC_CLIENT_SECRET = None
+    EMPLOYEE_TYPES = []
 
 
 class ProdConfig(Config):
@@ -53,3 +54,4 @@ class TestAuthConfig(TestConfig):
     OIDC_CLIENT_ID = 'estuary'
     OIDC_CLIENT_SECRET = 'some_secret'
     ENABLE_AUTH = True
+    EMPLOYEE_TYPES = ['Employee', 'International Local Hire']

--- a/estuary/utils/general.py
+++ b/estuary/utils/general.py
@@ -159,8 +159,8 @@ def login_required(f):
                 raise Unauthorized(validity)
 
             token_info = current_app.oidc._get_token_info(token)
-            if (token_info.get('employeeType') != 'Employee'
-                    and token_info.get('employeeType') != 'International Local Hire'):
+            employee_types = current_app.config.get('EMPLOYEE_TYPES', [])
+            if employee_types and token_info.get('employeeType') not in employee_types:
                 raise Unauthorized('You must be an employee to access this service')
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
Allow the monitoring service, which has the employeeType of `estuary`, to access the Estuary API.