### PR TITLE
Don't validate the CA of the server when downloading the CA

### DIFF
--- a/docker/install-ca.sh
+++ b/docker/install-ca.sh
@@ -2,7 +2,7 @@
 
 if [ -n "${CA_URL}" ] && [ ! -f "/tmp/.imported" ]; then
     # Since update-ca-trust doesn't work as a non-root user, let's just append to the bundle directly
-    curl --silent --show-error "${CA_URL}" >> /etc/pki/tls/certs/ca-bundle.crt
+    curl -k --silent --show-error "${CA_URL}" >> /etc/pki/tls/certs/ca-bundle.crt
     # Create a file so we know not to import it again if the container is restarted
     touch /tmp/.imported
 fi


### PR DESCRIPTION
In the event the remote server has a certificate with a custom CA, we need to be able to download the CA regardless.