### PR TITLE
Set the cardinality on FreshmakerBuild.event

### DIFF
--- a/estuary/models/freshmaker.py
+++ b/estuary/models/freshmaker.py
@@ -47,7 +47,7 @@ class FreshmakerBuild(EstuaryStructuredNode):
     type_name = StringProperty()
     url = StringProperty()
     koji_builds = RelationshipTo('.koji.ContainerKojiBuild', 'TRIGGERED_BY', cardinality=ZeroOrOne)
-    event = RelationshipFrom('.FreshmakerEvent', 'TRIGGERED')
+    event = RelationshipFrom('.FreshmakerEvent', 'TRIGGERED', cardinality=ZeroOrOne)
 
     @property
     def display_name(self):

--- a/scrapers/freshmaker.py
+++ b/scrapers/freshmaker.py
@@ -93,7 +93,7 @@ class FreshmakerScraper(BaseScraper):
                         fb_params['time_completed'] = timestamp_to_datetime(
                             build_dict['time_completed'])
                     fb = FreshmakerBuild.create_or_update(fb_params)[0]
-                    fb.event.connect(event)
+                    fb.event.conditional_connect(event)
                     event.requested_builds.connect(fb)
 
                     # The build ID obtained from Freshmaker API is actually a Koji task ID


### PR DESCRIPTION
This is important because it changes the way the `serialized_all` method will convert the relationship to JSON. If the cardinality is ZeroOrOne, then `serialized_all` will not use a list to represent this.