### PR TITLE
Fix a typo in the Freshmaker scraper

### DIFF
--- a/scrapers/freshmaker.py
+++ b/scrapers/freshmaker.py
@@ -93,7 +93,6 @@ class FreshmakerScraper(BaseScraper):
                         fb_params['time_completed'] = timestamp_to_datetime(
                             build_dict['time_completed'])
                     fb = FreshmakerBuild.create_or_update(fb_params)[0]
-                    fb.event.conditional_connect(event)
                     event.requested_builds.connect(fb)
 
                     # The build ID obtained from Freshmaker API is actually a Koji task ID


### PR DESCRIPTION
In the previous PR, I had made a mistake. This line that I'm deleting has a typo in it, but it's not actually needed because of the line below it.