### PR TITLE
Include the direct relationships of nodes in the recents endpoint

### DIFF
--- a/estuary/utils/recents.py
+++ b/estuary/utils/recents.py
@@ -46,7 +46,7 @@ def get_recent_nodes():
             node_results = final_result_data.setdefault(label, [])
             # result is always a list of a single node
             node = inflate_node(result[0])
-            serialized_node = node.serialized
+            serialized_node = node.serialized_all
             serialized_node['resource_type'] = node.__label__
             serialized_node['display_name'] = node.display_name
             node_results.append(serialized_node)


### PR DESCRIPTION
This will allow us to see the repos that DistGitCommits are attached to, which the front end needs to know in order to display them. 