### PR TITLE
Don't run get_koji_task_result when the Freshmaker build build_id is None

### DIFF
--- a/scrapers/freshmaker.py
+++ b/scrapers/freshmaker.py
@@ -112,7 +112,10 @@ class FreshmakerScraper(BaseScraper):
                     event.requested_builds.connect(fb)
 
                     # The build ID obtained from Freshmaker API is actually a Koji task ID
-                    task_result = self.get_koji_task_result(build_dict['build_id'])
+                    task_result = None
+                    if build_dict['build_id']:
+                        task_result = self.get_koji_task_result(build_dict['build_id'])
+
                     if not task_result:
                         continue
 


### PR DESCRIPTION
This should fix the traceback:
```
[teiid.py:104:query] Querying Teiid DB "public" with SQL:
--
  | SELECT result
  | FROM brew.task
  | WHERE id = None;
  |  
  | Traceback (most recent call last):
  | File "scripts/scrape.py", line 70, in <module>
  | scraper.run(since=since, until=args.until)
  | File "/src/scrapers/freshmaker.py", line 34, in run
  | self.query_api_and_update_neo4j()
  | File "/src/scrapers/freshmaker.py", line 115, in query_api_and_update_neo4j
  | task_result = self.get_koji_task_result(build_dict['build_id'])
  | File "/src/scrapers/freshmaker.py", line 171, in get_koji_task_result
  | return self.teiid.query(sql=sql_query)[0]['result']
  | File "/src/scrapers/teiid.py", line 116, in query
  | cursor.execute(sql)
  | psycopg2.OperationalError: TEIID31100 Parsing error: Encountered "WHERE id = [*]None[*]" at line 3, column 24.
```